### PR TITLE
Use MSnbase to get correct scan number and not index from scans

### DIFF
--- a/SpectrumAI.R
+++ b/SpectrumAI.R
@@ -1,5 +1,7 @@
-library(mzR)
+#!/usr/bin/env Rscript
+
 library(protViz)
+library(MSnbase)
 library(stringr)
 
 
@@ -66,10 +68,11 @@ InspectSpectrum <- function (DF){
         seq=DF[i,]$Sequence
         
         if (is.null(Spectra_list[[spectra_file]])){
-            Spectra_list[[spectra_file]]=openMSfile(mzml_file,verbose=T)
+            Spectra_list[[spectra_file]]=spectra(readMSData(mzml_file))
         }
         
-        exp_peaks<-peaks(Spectra_list[[spectra_file]],scan=ScanNum)
+        spectrum = Filter(function(f) acquisitionNum(f)==ScanNum, Spectra_list[[spectra_file]])[[1]]
+        exp_peaks = cbind(mz(spectrum), intensity(spectrum))
         predicted_peaks = predict_MS2_spectrum(Peptide =  as.character(DF[i,]$Peptide))
         match_ions = match_exp2predicted(exp_peaks, predicted_peaks, tolerance =Frag.ions.tolerance, relative = relative )
         

--- a/SpectrumAI.R
+++ b/SpectrumAI.R
@@ -18,6 +18,7 @@ use.interactive = F
 
 if (use.interactive) {
        source('./Spectra_functions.R')
+       enforce_scans = FALSE
 } else {
         args = commandArgs(trailingOnly = F)  # For scripted use
         # Get script file location when running RScript
@@ -30,6 +31,7 @@ if (use.interactive) {
         mzml_path= cmargs[1]
         infile_name = cmargs[2]
         outfile_name = cmargs[3]
+	if (length(cmargs) == 4) enforce_scans = cmargs[4] == '--enforce-scans' else enforce_scans = FALSE
 }
 
 
@@ -68,11 +70,19 @@ InspectSpectrum <- function (DF){
         seq=DF[i,]$Sequence
         
         if (is.null(Spectra_list[[spectra_file]])){
-            Spectra_list[[spectra_file]]=spectra(readMSData(mzml_file))
+            if (enforce_scans) {
+                Spectra_list[[spectra_file]] = readMSData(mzml_file, mode="onDisk")
+            } else {
+                Spectra_list[[spectra_file]] = openMSfile(mzml_file, verbose=T)
+            }
+        }
+        if (enforce_scans) {
+            spectrum = Spectra_list[[spectra_file]][[ which(acquisitionNum(Spectra_list[[spectra_file]])==ScanNum) ]]
+            exp_peaks = cbind(mz(spectrum), intensity(spectrum))
+        } else {
+            exp_peaks <- peaks(Spectra_list[[spectra_file]], scan=ScanNum)
         }
         
-        spectrum = Filter(function(f) acquisitionNum(f)==ScanNum, Spectra_list[[spectra_file]])[[1]]
-        exp_peaks = cbind(mz(spectrum), intensity(spectrum))
         predicted_peaks = predict_MS2_spectrum(Peptide =  as.character(DF[i,]$Peptide))
         match_ions = match_exp2predicted(exp_peaks, predicted_peaks, tolerance =Frag.ions.tolerance, relative = relative )
         


### PR DESCRIPTION
When using `peaks(spectra, scan=number)` the number is a 1-based index of all scans in the mzML file. This is fine when not filtering mzML files since the instrument-assigned scan numbers are identical to this.

But I have some filtered data to make a small mzML file for testing and then the scan numbers are e.g. `[5,20,34,754,1203,...]`, while the indices are `[1,2,3,4,5,...]`.

To fetch scan numbers correctly even in this scenario I have made it so that the spectrum is fetched by its `acquisitionNum` from `MSnbase`. See also here https://github.com/sneumann/mzR/issues/187